### PR TITLE
fix: correct image registry casing in values.yaml

### DIFF
--- a/charts/rustcloak-operator/values.yaml
+++ b/charts/rustcloak-operator/values.yaml
@@ -8,7 +8,7 @@ application:
   legacy: false
 
 image:
-  registry: ghcr.io/DenktMit-eG/rustcloak-operator
+  registry: ghcr.io/denktmit-eg/rustcloak-operator
   repository: rustcloak-operator
   pullPolicy: IfNotPresent
   tag: ""


### PR DESCRIPTION
The registry name casing was inconsistent, causing potential issues with image pulling. Adjusted the registry name to match the correct lowercase format.