### PR TITLE
ApiObjectController: fix protocol mappers

### DIFF
--- a/charts/rustcloak-operator/crds/clusterkeycloakapiobjects.rustcloak.k8s.eboland.de.yaml
+++ b/charts/rustcloak-operator/crds/clusterkeycloakapiobjects.rustcloak.k8s.eboland.de.yaml
@@ -194,6 +194,10 @@ spec:
                 type: object
               payload:
                 type: string
+              primaryKey:
+                description: The name of the primary key field in the payload (e.g. "id", "name", "alias"). Used to inject the resource ID extracted from the stored resource path into PUT requests, working around Keycloak versions that don't populate the model ID from the URL path parameter.
+                nullable: true
+                type: string
             required:
             - endpoint
             - immutablePayload

--- a/charts/rustcloak-operator/crds/keycloakapiobjects.rustcloak.k8s.eboland.de.yaml
+++ b/charts/rustcloak-operator/crds/keycloakapiobjects.rustcloak.k8s.eboland.de.yaml
@@ -194,6 +194,10 @@ spec:
                 type: object
               payload:
                 type: string
+              primaryKey:
+                description: The name of the primary key field in the payload (e.g. "id", "name", "alias"). Used to inject the resource ID extracted from the stored resource path into PUT requests, working around Keycloak versions that don't populate the model ID from the URL path parameter.
+                nullable: true
+                type: string
             required:
             - endpoint
             - immutablePayload

--- a/docs/src/crds/clusterkeycloakapiobject.md
+++ b/docs/src/crds/clusterkeycloakapiobject.md
@@ -34,6 +34,7 @@ Custom Resource for Keycloak API requests. The user should not use this resource
 |[spec.options.patchFrom[].value](#specoptionspatchfromvalue)|string||
 |[spec.options.patchFrom[].value_as](#specoptionspatchfromvalueas)|string||
 |[spec.payload](#specpayload)|string|✅|
+|[spec.primaryKey](#specprimarykey)|string||
 |[status](#status)|object||
 |[status.conditions[]](#statusconditions)|object||
 |[status.conditions[].lastTransitionTime](#statusconditionslasttransitiontime)|string||
@@ -64,6 +65,7 @@ Type: object
 |[immutablePayload](#specimmutablepayload)|string|✅|
 |[options](#specoptions)|object||
 |[payload](#specpayload)|string|✅|
+|[primaryKey](#specprimarykey)|string||
 
 defines an API request to the Keycloak Admin API.
 
@@ -362,6 +364,14 @@ Type: string
 Type: string
 
 *missing*
+
+---
+
+### spec.primaryKey
+
+Type: string
+
+The name of the primary key field in the payload (e.g. "id", "name", "alias"). Used to inject the resource ID extracted from the stored resource path into PUT requests, working around Keycloak versions that don't populate the model ID from the URL path parameter.
 
 ---
 

--- a/docs/src/crds/keycloakapiobject.md
+++ b/docs/src/crds/keycloakapiobject.md
@@ -34,6 +34,7 @@ Custom Resource for Keycloak API requests. The user should not use this resource
 |[spec.options.patchFrom[].value](#specoptionspatchfromvalue)|string||
 |[spec.options.patchFrom[].value_as](#specoptionspatchfromvalueas)|string||
 |[spec.payload](#specpayload)|string|✅|
+|[spec.primaryKey](#specprimarykey)|string||
 |[status](#status)|object||
 |[status.conditions[]](#statusconditions)|object||
 |[status.conditions[].lastTransitionTime](#statusconditionslasttransitiontime)|string||
@@ -64,6 +65,7 @@ Type: object
 |[immutablePayload](#specimmutablepayload)|string|✅|
 |[options](#specoptions)|object||
 |[payload](#specpayload)|string|✅|
+|[primaryKey](#specprimarykey)|string||
 
 defines an API request to the Keycloak Admin API.
 
@@ -362,6 +364,14 @@ Type: string
 Type: string
 
 *missing*
+
+---
+
+### spec.primaryKey
+
+Type: string
+
+The name of the primary key field in the payload (e.g. "id", "name", "alias"). Used to inject the resource ID extracted from the stored resource path into PUT requests, working around Keycloak versions that don't populate the model ID from the URL path parameter.
 
 ---
 

--- a/rustcloak-crd/src/crd/api_object.rs
+++ b/rustcloak-crd/src/crd/api_object.rs
@@ -30,6 +30,13 @@ both_scopes! {
             pub endpoint: KeycloakApiEndpoint,
             pub immutable_payload: ImmutableString,
             pub payload: String,
+            /// The name of the primary key field in the payload (e.g. "id",
+            /// "name", "alias"). Used to inject the resource ID extracted
+            /// from the stored resource path into PUT requests, working
+            /// around Keycloak versions that don't populate the model ID
+            /// from the URL path parameter.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub primary_key: Option<String>,
         }
     }
 }

--- a/rustcloak-operator/src/controller/representation_controller.rs
+++ b/rustcloak-operator/src/controller/representation_controller.rs
@@ -222,6 +222,7 @@ where
                 options: resource.inner_spec().options().cloned(),
                 immutable_payload,
                 payload,
+                primary_key: Some(primary_key.to_string()),
             },
         );
 


### PR DESCRIPTION
protocol mappers fail to update when the request does not contain the id. Rustcloak now adds the ID to requests.